### PR TITLE
Removed the ! from the end of eventName

### DIFF
--- a/jquery.datalink.js
+++ b/jquery.datalink.js
@@ -77,11 +77,11 @@ $.extend({
 				var $this = $( target ),
 					args = [ parts[0], value ];
 
-			$this.triggerHandler( eventNameSetField + parts[1] + "!", args );
+			$this.triggerHandler( eventNameSetField + parts[1], args );
 			if ( value !== undefined ) {
 				target[ field ] = value;
 			}
-			$this.triggerHandler( eventNameChangeField + parts[1] + "!", args );
+			$this.triggerHandler( eventNameChangeField + parts[1], args );
 		}
 	}
 });


### PR DESCRIPTION
Due to jQuery version updates, the `!` added within the `.triggerHandler` function call causes the trigger events to be ignored.
